### PR TITLE
Remove protocol from JQuery URLs

### DIFF
--- a/biomixer/war/conceptPathToRoot.html
+++ b/biomixer/war/conceptPathToRoot.html
@@ -12,7 +12,7 @@
     <script type="text/javascript" src="./d3_graphs/purl.js"></script>
     
     <!-- jquery 2.x does not support IE 8,7, or 6, but 40% of visitors from IE8. -->
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
     <!--
     <script src="http://code.jquery.com/jquery-1.9.1.js"></script>
     -->
@@ -20,8 +20,8 @@
     <!--
     <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js"></script>
     -->
-	<script src="http://code.jquery.com/ui/1.10.3/jquery-ui.js"></script>
-    <link rel="stylesheet" href="http://code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css" type="text/css" />
+	<script src="//code.jquery.com/ui/1.10.3/jquery-ui.js"></script>
+    <link rel="stylesheet" href="//code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css" type="text/css" />
     
     <script type="text/javascript" src="./d3_graphs/jquery.simplemodal.1.4.4.min.js"></script>
     <link href="./d3_graphs/simplemodal_confirm.css" rel="stylesheet" type="text/css">

--- a/biomixer/war/index.html
+++ b/biomixer/war/index.html
@@ -12,7 +12,7 @@
     <script type="text/javascript" src="./d3_graphs/purl.js"></script>
     
     <!-- jquery 2.x does not support IE 8,7, or 6, but 40% of visitors from IE8. -->
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
     <!--
     <script src="http://code.jquery.com/jquery-1.9.1.js"></script>
     -->
@@ -20,8 +20,8 @@
     <!--
     <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js"></script>
     -->
-	<script src="http://code.jquery.com/ui/1.10.3/jquery-ui.js"></script>
-    <link rel="stylesheet" href="http://code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css" type="text/css" />
+	<script src="//code.jquery.com/ui/1.10.3/jquery-ui.js"></script>
+    <link rel="stylesheet" href="//code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css" type="text/css" />
     
     <script type="text/javascript" src="./d3_graphs/jquery.simplemodal.1.4.4.min.js"></script>
     <link href="./d3_graphs/simplemodal_confirm.css" rel="stylesheet" type="text/css">

--- a/biomixer/war/ontologyMappingOverview.html
+++ b/biomixer/war/ontologyMappingOverview.html
@@ -12,7 +12,7 @@
     <script type="text/javascript" src="./d3_graphs/purl.js"></script>
     
     <!-- jquery 2.x does not support IE 8,7, or 6, but 40% of visitors from IE8. -->
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
     <!--
     <script src="http://code.jquery.com/jquery-1.9.1.js"></script>
     -->
@@ -20,8 +20,8 @@
     <!--
     <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js"></script>
     -->
-	<script src="http://code.jquery.com/ui/1.10.3/jquery-ui.js"></script>
-    <link rel="stylesheet" href="http://code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css" type="text/css" />
+	<script src="//code.jquery.com/ui/1.10.3/jquery-ui.js"></script>
+    <link rel="stylesheet" href="//code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css" type="text/css" />
     
     <script type="text/javascript" src="./d3_graphs/jquery.simplemodal.1.4.4.min.js"></script>
     <link href="./d3_graphs/simplemodal_confirm.css" rel="stylesheet" type="text/css">


### PR DESCRIPTION
Fix for "Blocked loading mixed active content" errors when users try to access the BioPortal visualization widget over HTTPS, e.g., this URL works:

http://bioportal.bioontology.org/widgets/visualization/?ontology=NCBITAXON&class=http%3A%2F%2Fpurl.bioontology.org%2Fontology%2FNCBITAXON%2F5324

... but this one with https as the protocol displays a blank page:

https://bioportal.bioontology.org/widgets/visualization/?ontology=NCBITAXON&class=http%3A%2F%2Fpurl.bioontology.org%2Fontology%2FNCBITAXON%2F5324

... due to mixed content errors.
